### PR TITLE
Cleanup of third party extends

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -76,8 +76,6 @@ for ($i = 0; $i < 10; $i++) {
   // Ms. Karley Kiehn V
 ```
 
-**Tip**: For a quick generation of fake data, you can also use Faker as a command line tool thanks to [faker-cli](https://github.com/bit3/faker-cli).
-
 ## Formatters
 
 Each of the generator properties (like `name`, `address`, and `lorem`) are called "formatters". A faker generator has many of them, packaged in "providers". Here is a list of the bundled formatters in the default locale.
@@ -561,40 +559,28 @@ Supported locales can be found under the "Locales" header on the left.
 
 Source: <https://www.localeplanet.com/icu/>
 
-## Third-Party Libraries Extending/Based On Faker
+## Third-Party Libraries Extending/Based On FakerPHP
 
 - Symfony bundles:
   - [`willdurand/faker-bundle`](https://github.com/willdurand/BazingaFakerBundle): Put the awesome Faker library into the Symfony2 DIC and populate your database with fake data.
   - [`hautelook/alice-bundle`](https://github.com/hautelook/AliceBundle), [`h4cc/alice-fixtures-bundle`](https://github.com/h4cc/AliceFixturesBundle): Bundles for using [`nelmio/alice`](https://packagist.org/packages/nelmio/alice) and Faker with data fixtures. Able to use Doctrine ORM as well as Doctrine MongoDB ODM.
-- [`emanueleminotto/faker-service-provider`](https://github.com/EmanueleMinotto/FakerServiceProvider): Faker Service Provider for Silex
-- [`bit3/faker-cli`](https://github.com/bit3/faker-cli): Command Line Tool for the Faker PHP library
 - [`league/factory-muffin`](https://github.com/thephpleague/factory-muffin): enable the rapid creation of objects (PHP port of factory-girl)
-- [`fzaninotto/company-name-generator`](https://github.com/fzaninotto/CompanyNameGenerator): Generate names for English tech companies with class
 - [`emanueleminotto/faker-placehold-it-provider`](https://github.com/EmanueleMinotto/PlaceholdItProvider): Generate images using placehold.it
-- [`spyrit/datalea`](https://github.com/spyrit/datalea) A highly customizable random test data generator web app
 - [`frequenc1/newage-ipsum`](https://github.com/frequenc1/newage-ipsum): A new aged ipsum provider for the faker library inspired by http://sebpearce.com/bullshit/
-- [`prewk/xml-faker`](https://github.com/prewk/xml-faker): Create fake XML with Faker
 - [`denheck/faker-context`](https://github.com/denheck/faker-context): Behat context using Faker to generate testdata
 - [`swekaj/cron-expression-generator`](https://github.com/swekaj/CronExpressionGenerator): Faker provider for generating random, valid cron expressions.
-- [`pragmafabrik/pomm-faker`](https://github.com/pragmafabrik/Pomm2Faker): Faker client for Pomm database framework (PostgreSQL)
 - [`nelmio/alice`](https://github.com/nelmio/alice): Fixtures/object generator with a yaml DSL that can use Faker as data generator.
 - [`ravage84/cakephp-fake-seeder`](https://github.com/ravage84/cakephp-fake-seeder) A CakePHP 2.x shell to seed your database with fake and/or fixed data.
 - [`bheller/images-generator`](https://github.com/bruceheller/images-generator): An image generator provider using GD for placeholder type pictures
 - [`pattern-lab/plugin-faker`](https://github.com/pattern-lab/plugin-php-faker): Pattern Lab is a Styleguide, Component Library, and Prototyping tool. This creates unique content each time Pattern Lab is generated.
 - [`guidocella/eloquent-populator`](https://github.com/guidocella/eloquent-populator): Adapter for Laravel's Eloquent ORM.
-- [`tamperdata/exiges`](https://github.com/tamperdata/exiges): Faker provider for generating random temperatures
 - [`jzonta/faker-restaurant`](https://github.com/jzonta/FakerRestaurant): Faker for Food and Beverage names generate
 - [`aalaap/faker-youtube`](https://github.com/aalaap/faker-youtube): Faker for YouTube URLs in various formats
 - [`pelmered/fake-car`](https://github.com/pelmered/fake-car): Faker for cars and car data
 - [`bluemmb/faker-picsum-photos-provider`](https://github.com/bluemmb/Faker-PicsumPhotos): Generate images using [picsum.photos](http://picsum.photos/)
-- [`er1z/fakemock`](https://github.com/er1z/fakemock): Generate mocks using class-configuration and detection via Faker's guesser and Symfony asserts
 - [`xvladqt/faker-lorem-flickr`](https://github.com/xvladxtremal/Faker-LoremFlickr): Generate images using [loremflickr.com](http://loremflickr.com/)
-- [`metrakit/faker-eddy-malou`](https://github.com/Metrakit/faker-eddy-malou): Generate French Eddy Malou sentences & paragraphs
-- [`drupol/belgian-national-number-faker`](https://github.com/drupol/belgian-national-number-faker): Generate fake Belgian national numbers
-- [`elgentos/masquerade`](https://github.com/elgentos/masquerade): Configuration-based, platform-agnostic, locale-compatible data faker tool (out-of-the-box support for Magento 2)
 - [`ottaviano/faker-gravatar`](https://github.com/ottaviano/faker-gravatar): Generate avatars using [Gravatar](https://en.gravatar.com/site/implement/images/)
 - [`finwe/phpstan-faker`](https://github.com/finwe/phpstan-faker): PHPStan extension for Faker methods
-- [`springbokagency/faker-xpdo-orm-adapter`](https://github.com/SpringbokAgency/faker-xpdo-orm-adapter): A Faker ORM adapter to populate xPDO objects with fake data.
 
 ## License
 


### PR DESCRIPTION
Reviewed all libs. All libs < 4k uses have been removed even as all the other "old" stuff.

* emanueleminotto/faker-service-provider 2k installs
* bit3/faker-cli < Abandoned
* fzaninotto/company-name-generator < Abandoned
* spyrit/datalea < Non existing
* prewk/xml-faker < 1k installs
* pragmafabrik/pomm-faker < 500 installs
* tamperdata/exiges < 23 installs
* er1z/fakemock : 1k
* metrakit/faker-eddy-malou 1k
* drupol/belgian-national-number-faker: 14
* elgentos/masquerade: 1
* springbokagency/faker-xpdo-orm-adapter : 14 + bad invalid copy/paste docs