### PR TITLE
Add missing bank account number docs

### DIFF
--- a/docs/locales/bg_BG.md
+++ b/docs/locales/bg_BG.md
@@ -3,6 +3,7 @@
 ### `Faker\Provider\bg_BG\Payment`
 
 ```php
-echo $faker->vat;           // "BG 0123456789" - Bulgarian Value Added Tax number
-echo $faker->vat(false);    // "BG0123456789" - unspaced Bulgarian Value Added Tax number
+echo $faker->bankAccountNumber; // "BG89ZHIA63939899TD7TC8"
+echo $faker->vat;               // "BG 0123456789" - Bulgarian Value Added Tax number
+echo $faker->vat(false);        // "BG0123456789" - unspaced Bulgarian Value Added Tax number
 ```

--- a/docs/locales/cs_CZ.md
+++ b/docs/locales/cs_CZ.md
@@ -20,6 +20,12 @@ echo $faker->monthNameGenitive; // "prosince"
 echo $faker->formattedDate; // "12. listopadu 2015"
 ```
 
+### `Faker\Provider\cs_CZ\Payment`
+
+```php
+echo $faker->bankAccountNumber; // "CZ2318941673853266249134"
+```
+
 ### `Faker\Provider\cs_CZ\Person`
 
 ```php

--- a/docs/locales/da_DK.md
+++ b/docs/locales/da_DK.md
@@ -26,3 +26,9 @@ echo $faker->cvr; // "32458723"
 // Generates a random P number
 echo $faker->p; // "5398237590"
 ```
+
+### `Faker\Provider\da_DK\Payment`
+
+```php
+echo $faker->bankAccountNumber; // "DK4482839445577922"
+```

--- a/docs/locales/de_AT.md
+++ b/docs/locales/de_AT.md
@@ -1,8 +1,9 @@
 # German (Austria)
 
-### `Faker\Provider\at_AT\Payment`
+### `Faker\Provider\de_AT\Payment`
 
 ```php
-echo $faker->vat;           // "AT U12345678" - Austrian Value Added Tax number
-echo $faker->vat(false);    // "ATU12345678" - unspaced Austrian Value Added Tax number
+echo $faker->bankAccountNumber; // "SA0218IBYZVZJSEC8536V4XC"
+echo $faker->vat;               // "AT U12345678" - Austrian Value Added Tax number
+echo $faker->vat(false);        // "ATU12345678" - unspaced Austrian Value Added Tax number
 ```

--- a/docs/locales/de_CH.md
+++ b/docs/locales/de_CH.md
@@ -1,5 +1,11 @@
 # German (Switzerland)
 
+### `Faker\Provider\de_CH\Payment`
+
+```php
+echo $faker->bankAccountNumber; // "CH28167004ZG2ZU4X0H47"
+```
+
 ### `Faker\Provider\de_CH\Person`
 
 ```php

--- a/docs/locales/el_CY.md
+++ b/docs/locales/el_CY.md
@@ -1,0 +1,7 @@
+# Greek (Cyprus)
+
+### `Faker\Provider\el_CY\Payment`
+
+```php
+echo $faker->bankAccountNumber; // "CY52603169440XP3ZL20NAZ084I1"
+```

--- a/docs/locales/el_GR.md
+++ b/docs/locales/el_GR.md
@@ -1,0 +1,7 @@
+# Greek (Greece)
+
+### `Faker\Provider\el_GR\Payment`
+
+```php
+echo $faker->bankAccountNumber; // "GR173660451Z7ZO3VW6FR8Z99JT"
+```

--- a/docs/locales/en_GB.md
+++ b/docs/locales/en_GB.md
@@ -1,0 +1,7 @@
+# English (United Kingdom)
+
+### `Faker\Provider\en_GB\Payment`
+
+```php
+echo $faker->bankAccountNumber; // "GB28MLRJ42074399970100"
+```

--- a/docs/locales/es_ES.md
+++ b/docs/locales/es_ES.md
@@ -13,6 +13,8 @@ echo $faker->licenceCode; // B
 ### `Faker\Provider\es_ES\Payment`
 
 ```php
+echo $faker->bankAccountNumber; // "ES5285748762396535068585"
+
 // Generates a Código de identificación Fiscal (CIF) number
 echo $faker->vat;           // "A35864370"
 ```

--- a/docs/locales/fr_BE.md
+++ b/docs/locales/fr_BE.md
@@ -3,6 +3,7 @@
 ### `Faker\Provider\fr_BE\Payment`
 
 ```php
-echo $faker->vat;           // "BE 0123456789" - Belgian Value Added Tax number
-echo $faker->vat(false);    // "BE0123456789" - unspaced Belgian Value Added Tax number
+echo $faker->bankAccountNumber; // "BE22800006647946"
+echo $faker->vat;               // "BE 0123456789" - Belgian Value Added Tax number
+echo $faker->vat(false);        // "BE0123456789" - unspaced Belgian Value Added Tax number
 ```

--- a/docs/locales/fr_CH.md
+++ b/docs/locales/fr_CH.md
@@ -1,6 +1,13 @@
 # French (Switzerland)
 
+### `Faker\Provider\fr_CH\Payment`
+
+```php
+echo $faker->bankAccountNumber; // "CH28167004ZG2ZU4X0H47"
+```
+
 ### `Faker\Provider\fr_CH\Person`
+
 ```php
 // Generates a random AVS13/AHV13 social security number
 echo $faker->avs13; // "756.1234.5678.97"

--- a/docs/locales/fr_FR.md
+++ b/docs/locales/fr_FR.md
@@ -32,6 +32,8 @@ echo $faker->siret; // 347 355 708 00224
 ### `Faker\Provider\fr_FR\Payment`
 
 ```php
+echo $faker->bankAccountNumber; // "FR982713192809U43A8QR4OJ923"
+
 // Generates a random VAT
 echo $faker->vat; // FR 12 123 456 789
 ```


### PR DESCRIPTION
The payment provider `bankAccountNumber` doc was missing in some locales (but present in 16 others, e.g. [Poland](https://github.com/FakerPHP/fakerphp.github.io/blob/a7868b0496d116e305811da1d2e99f6c740c992f/docs/locales/pl_PL.md#L29)). This PR adds this for some locales.