### PR TITLE
Add more missing bank account number docs

### DIFF
--- a/docs/locales/is_IS.md
+++ b/docs/locales/is_IS.md
@@ -1,0 +1,7 @@
+# Icelandic (Iceland)
+
+### `Faker\Provider\is_IS\Payment`
+
+```php
+echo $faker->bankAccountNumber; // "IS772061465007570166313591"
+```

--- a/docs/locales/it_CH.md
+++ b/docs/locales/it_CH.md
@@ -1,5 +1,12 @@
 # Italian (Switzerland)
 
+### `Faker\Provider\it_CH\Payment`
+
+```php
+echo $faker->bankAccountNumber; // "CH28167004ZG2ZU4X0H47"
+```
+
+
 ### `Faker\Provider\it_CH\Person`
 
 ```php

--- a/docs/locales/it_IT.md
+++ b/docs/locales/it_IT.md
@@ -7,6 +7,12 @@
 echo $faker->vatId(); // "IT98746784967"
 ```
 
+### `Faker\Provider\it_IT\Payment`
+
+```php
+echo $faker->bankAccountNumber; // "IT53H9229628427XEQQOX0CU8Z0"
+```
+
 ### `Faker\Provider\it_IT\Person`
 
 ```php

--- a/docs/locales/lv_LV.md
+++ b/docs/locales/lv_LV.md
@@ -1,5 +1,11 @@
 # Latvian (Latvia)
 
+### `Faker\Provider\lv_LV\Payment`
+
+```php
+echo $faker->bankAccountNumber; // "LV56XUHF3FI0W5413NIP0"
+```
+
 ### `Faker\Provider\lv_LV\Person`
 
 ```php

--- a/docs/locales/me_ME.md
+++ b/docs/locales/me_ME.md
@@ -1,0 +1,7 @@
+# Montenegrin (Montenegro)
+
+### `Faker\Provider\me_ME\Payment`
+
+```php
+echo $faker->bankAccountNumber; // "ME62304676623331330300"
+```

--- a/docs/locales/nl_BE.md
+++ b/docs/locales/nl_BE.md
@@ -3,8 +3,9 @@
 ### `Faker\Provider\nl_BE\Payment`
 
 ```php
-echo $faker->vat;           // "BE 0123456789" - Belgian Value Added Tax number
-echo $faker->vat(false);    // "BE0123456789" - unspaced Belgian Value Added Tax number
+echo $faker->bankAccountNumber; // "BE74249767372336"
+echo $faker->vat;               // "BE 0123456789" - Belgian Value Added Tax number
+echo $faker->vat(false);        // "BE0123456789" - unspaced Belgian Value Added Tax number
 ```
 
 ### `Faker\Provider\nl_BE\Person`

--- a/docs/locales/nl_NL.md
+++ b/docs/locales/nl_NL.md
@@ -8,6 +8,12 @@ echo $faker->vat; // "NL123456789B01" - Dutch Value Added Tax number
 echo $faker->btw; // "NL123456789B01" - Dutch Value Added Tax number (alias)
 ```
 
+### `Faker\Provider\nl_NL\Payment`
+
+```php
+echo $faker->bankAccountNumber; // "NL74MNEJ4830302492"
+```
+
 ### `Faker\Provider\nl_NL\Person`
 
 ```php

--- a/docs/locales/pt_BR.md
+++ b/docs/locales/pt_BR.md
@@ -31,6 +31,12 @@ echo $faker->phoneNumber;           // formatted, random landline or cellphone (
 echo $faker->phoneNumberCleared;    // not formatted, random landline or cellphone (obeying the 9th digit rule)
 ```
 
+### `Faker\Provider\pt_BR\Payment`
+
+```php
+echo $faker->bankAccountNumber; // "BR0506997786328342762640926MO"
+```
+
 ### `Faker\Provider\pt_BR\Person`
 
 ```php

--- a/docs/locales/pt_PT.md
+++ b/docs/locales/pt_PT.md
@@ -6,3 +6,9 @@
 // Generates a random taxpayer identification number (in portuguese - Número de Identificação Fiscal NIF)
 echo $faker->taxpayerIdentificationNumber; // '165249277'
 ```
+
+### `Faker\Provider\pt_PT\Payment`
+
+```php
+echo $faker->bankAccountNumber; // "PT54276294522742987131120"
+```

--- a/docs/locales/sk_SK.md
+++ b/docs/locales/sk_SK.md
@@ -1,0 +1,8 @@
+# Slovak (Slovakia)
+
+### `Faker\Provider\sk_SK\Payment`
+
+```php
+// Generates a random bank account number
+echo $faker->bankAccountNumber; // "SK6413578310194914530894"
+```

--- a/docs/locales/sl_SI.md
+++ b/docs/locales/sl_SI.md
@@ -1,0 +1,8 @@
+# Slovenian (Slovenia)
+
+### `Faker\Provider\sl_SI\Payment`
+
+```php
+// Generates a random bank account number
+echo $faker->bankAccountNumber; // "SI54033367976489565"
+```

--- a/docs/locales/sr_Cyrl_RS.md
+++ b/docs/locales/sr_Cyrl_RS.md
@@ -1,0 +1,8 @@
+# Serbian (Cyrillic, Serbia)
+
+### `Faker\Provider\sr_Cyrl_RS\Payment`
+
+```php
+// Generates a random bank account number
+echo $faker->bankAccountNumber; // "RS67272104347913868782"
+```

--- a/docs/locales/sr_Latn_RS.md
+++ b/docs/locales/sr_Latn_RS.md
@@ -1,0 +1,8 @@
+# Serbian (Latin, Serbia)
+
+### `Faker\Provider\sr_Latn_RS\Payment`
+
+```php
+// Generates a random bank account number
+echo $faker->bankAccountNumber; // "RS67272104347913868782"
+```

--- a/docs/locales/sr_RS.md
+++ b/docs/locales/sr_RS.md
@@ -1,0 +1,8 @@
+# Serbian (Serbia)
+
+### `Faker\Provider\sr_RS\Payment`
+
+```php
+// Generates a random bank account number
+echo $faker->bankAccountNumber; // "RS67272104347913868782"
+```

--- a/docs/locales/tr_TR.md
+++ b/docs/locales/tr_TR.md
@@ -1,5 +1,11 @@
 # Turkish (Turkey)
 
+### `Faker\Provider\tr_TR\Payment`
+
+```php
+echo $faker->bankAccountNumber; // "TR10701615J9D2W2U91686NSE1"
+```
+
 ### `Faker\Provider\tr_TR\Person`
 
 ```php


### PR DESCRIPTION
Part two of #20 - now all every localized `bankAccountNumber` is reflected in the documentation. 