### PR TITLE
Fix ar_SA doc

### DIFF
--- a/docs/locales/ar_SA.md
+++ b/docs/locales/ar_SA.md
@@ -1,16 +1,30 @@
 # Arabic (Saudi Arabia)
 
-### `Faker\Provider\ar_SA\Person`
+### `Faker\Provider\ar_SA\Address`
 
 ```php
-echo $faker->idNumber;      // ID number
-echo $faker->nationalIdNumber // Citizen ID number
-echo $faker->foreignerIdNumber // Foreigner ID number
-echo $faker->companyIdNumber // Company ID number
+echo $faker->governorate // "منطقة الجوف"
+echo $faker->subdivision // "منطقة الرياض"
 ```
+
+### `Faker\Provider\ar_SA\Company`
+
+```php
+echo $faker->companyIdNumber // "7008914645"
+```
+
 
 ### `Faker\Provider\ar_SA\Payment`
 
 ```php
 echo $faker->bankAccountNumber // "SA0218IBYZVZJSEC8536V4XC"
 ```
+
+### `Faker\Provider\ar_SA\Person`
+
+```php
+echo $faker->idNumber;          // ID number
+echo $faker->nationalIdNumber   // Citizen ID number
+echo $faker->foreignerIdNumber  // Foreigner ID number
+```
+


### PR DESCRIPTION
The documentation had `companyIdNumber` in the `Person` provider instead of in `Company`. `Address` methods were missing.