### PR TITLE
Fixed typo with timezone

### DIFF
--- a/docs/formatters/date-and-time.md
+++ b/docs/formatters/date-and-time.md
@@ -290,7 +290,7 @@ echo $faker->century();
 Generate a random timezone name.
 
 ```php
-echo $faker->century();
+echo $faker->timezone();
 
 // 'Europe/Amsterdam', 'America/Montreal'
 ```


### PR DESCRIPTION
There was a typo with timezone. It was century() instead of timezone().