### PR TITLE
Document available methods for `fr_BE` locale

### DIFF
--- a/docs/locales/fr_BE.md
+++ b/docs/locales/fr_BE.md
@@ -1,9 +1,52 @@
 # French (Belgium)
 
+### `Faker\Provider\fr_BE\Address`
+
+```php
+echo $faker->province(); // "Brabant wallon"
+echo $faker->cityName(); // "La Roche-en-Ardenne"
+```
+
+### `Faker\Provider\fr_BE\Company`
+
+```php
+echo $faker->company(); // "Timmermans SA"
+echo $faker->companySuffix(); // "ASBL"
+```
+
+### `Faker\Provider\fr_BE\Internet`
+
+```php
+echo $faker->tld(); // "be"
+```
+
 ### `Faker\Provider\fr_BE\Payment`
 
 ```php
+// IBAN for a Belgian bank account. Will always start with "BE".
 echo $faker->bankAccountNumber(); // "BE22800006647946"
-echo $faker->vat();               // "BE 0123456789" - Belgian Value Added Tax number
-echo $faker->vat(false);          // "BE0123456789" - unspaced Belgian Value Added Tax number
+
+// VAT number.
+echo $faker->vat(); // "BE 0123456789"
+
+// Same as above but without any space between country code and number.
+echo $faker->vat(false); // "BE0123456789"
+```
+
+### `Faker\Provider\fr_BE\Person`
+
+```php
+echo $faker->firstNameFemale(); // "Marion"
+echo $faker->firstNameMale(); // "Maxime"
+
+echo $faker->lastName(); // "Janssens"
+
+echo $faker->titleFemale(); // "Dr."
+echo $faker->titleMale(); // "M."
+```
+
+### `Faker\Provider\fr_BE\PhoneNumber`
+
+```php
+echo $faker->phoneNumber(); // "+32(0)2 9398787"
 ```


### PR DESCRIPTION
It turns out the providers for the `fr_BE` locale have a few bugs. And they could also be greatly improved.

But before proposing any code change, I thought it would make sense to update the docs so that they reflect the actual state of the locale. Right now, quite a few things are still undocumented.

So this PR updates the docs to add currently missing methods and it also documents “standard” methods (e.g. `cityName()`) that have undocumented customizations for `fr_BE`.