### PR TITLE
FIX typo in formatters/miscellaneous.md

### DIFF
--- a/docs/formatters/miscellaneous.md
+++ b/docs/formatters/miscellaneous.md
@@ -88,7 +88,7 @@ echo $faker->languageCode();
 
 ## `currencyCode`
 
-Generate a random [current code](https://en.wikipedia.org/wiki/ISO_4217) `string`.
+Generate a random [currency code](https://en.wikipedia.org/wiki/ISO_4217) `string`.
 
 ```php
 echo $faker->currencyCode();


### PR DESCRIPTION
FIX typo : "current code" => "currency code"