### PR TITLE
Fix typo in date & time docs

### DIFF
--- a/docs/formatters/date-and-time.md
+++ b/docs/formatters/date-and-time.md
@@ -178,7 +178,7 @@ An optional second parameter can be supplied, with the timezone.
 ```php
 echo $faker->dateTimeThisMonth();
 
-// a date somewhere in this months
+// a date somewhere in this month
 
 echo $faker->dateTimeThisMonth('+12 days');
 


### PR DESCRIPTION
When reading the docs, I spotted this small typo.