### PR TITLE
Update third-party.md with link to faker-schools

### DIFF
--- a/docs/third-party.md
+++ b/docs/third-party.md
@@ -5,6 +5,7 @@
 - [`pelmered/fake-car`](https://github.com/pelmered/fake-car): Faker for cars and car data
 - [`guidocella/eloquent-populator`](https://github.com/guidocella/eloquent-populator): Adapter for Laravel's Eloquent ORM.
 - [`jzonta/faker-restaurant`](https://github.com/jzonta/FakerRestaurant): Faker for Food and Beverage names generate
+- [`kenny-mwi/faker-schools`](https://github.com/Kenny-MWI/FakerSchools): Faker for high school, college, and university names
 - [`aalaap/faker-youtube`](https://github.com/aalaap/faker-youtube): Faker for YouTube URLs in various formats
 - [`bluemmb/faker-picsum-photos-provider`](https://github.com/bluemmb/Faker-PicsumPhotos): Generate images using [picsum.photos](http://picsum.photos/)
 - [`xvladqt/faker-lorem-flickr`](https://github.com/xvladxtremal/Faker-LoremFlickr): Generate images using [loremflickr.com](http://loremflickr.com/)


### PR DESCRIPTION
I made a little third-party library to generate fake high school, college, and university names for en_US and sv_SE locales. Can we add it to the list? 

> [`kenny-mwi/faker-schools`](https://github.com/Kenny-MWI/FakerSchools): Faker for high school, college, and university names