### PR TITLE
Swedish, publishable and GDPR safe number series

### DIFF
--- a/docs/locales/sv_SE.md
+++ b/docs/locales/sv_SE.md
@@ -29,3 +29,19 @@ echo $faker->mobileNumber(); // "07########"
 echo $faker->mobileNumber(); // "07## ## ## ##"
 echo $faker->mobileNumber(); // "07## ### ###"
 ```
+
+### Publishable and GDPR safe number series
+The [Swedish Post and Telecom Authority (PTS) have reserved number series](https://www.pts.se/sv/bransch/telefoni/nummer-och-adressering/telefonnummer-for-anvandning-i-bocker-och-filmer-etc/) that are safe to use in relation to European GDPR laws.
+<br>The numbers will never be used by any subscriber wich also makes them safe to publish in books, movies, TV series etc. 
+
+```php
+//Publishable Swedish mobile phone number series
+echo '070-1740' . $faker->faker->numberBetween(605, 699);
+
+//Publishable Swedish landline phone number series
+echo '031-3900' . $faker->numberBetween(600, 699);
+echo '040-6280' . $faker->numberBetween(400, 499);
+echo '08-46500' . $faker->numberBetween(400, 499);
+echo '0980-319' . $faker->numberBetween(200, 299);
+```
+


### PR DESCRIPTION
Since making the PR #71 for Swedish mobile phone numbers, it was brought to my attention that Faker phone numbers may generate "live" numbers. (Not just the Swedish generators). 

As the Swedish Post and Telecom Authority has reserved number series I thought best to add this information to the documentation.

Creds to Andreas Nilsson (Stockholm/Sweden).

@see https://www.pts.se/sv/bransch/telefoni/nummer-och-adressering/telefonnummer-for-anvandning-i-bocker-och-filmer-etc/

(Unable to find an English translation)