### PR TITLE
Update numbers-and-strings.md

### DIFF
--- a/docs/formatters/numbers-and-strings.md
+++ b/docs/formatters/numbers-and-strings.md
@@ -140,7 +140,7 @@ echo $faker->shuffle([1, 2, 3]);
 
 ## `numerify`
 
-Generate a string where all `#` characters are replaced by digits between 0 and 10. By default, `###` is used as input.
+Generate a string where all `#` characters are replaced by digits between 0 and 9. By default, `###` is used as input.
 
 ```php
 echo $faker->numerify();


### PR DESCRIPTION
replacing '#' characters with digits between 0 and 10 would create a string one character longer than desired 9% of the time.  This is a correction for the docs, hopefully numerify() doesn't actually do what the docs describe in this case.