### PR TITLE
add stripe id faker to third party libraries

### DIFF
--- a/docs/third-party.md
+++ b/docs/third-party.md
@@ -3,6 +3,7 @@
 - [`aalaap/faker-youtube`](https://github.com/aalaap/faker-youtube): Faker for YouTube URLs in various formats
 - [`bluemmb/faker-picsum-photos-provider`](https://github.com/bluemmb/Faker-PicsumPhotos): Generate images using [picsum.photos](http://picsum.photos/)
 - [`guidocella/eloquent-populator`](https://github.com/guidocella/eloquent-populator): Adapter for Laravel's Eloquent ORM.
+- [`jonpurvis/faker-stripe`](https://github.com/JonPurvis/faker-stripe): Generates fake, but structurally correct IDs for Stripe API resources.
 - [`jzonta/faker-restaurant`](https://github.com/jzonta/FakerRestaurant): Faker for Food and Beverage names generate
 - [`league/factory-muffin`](https://github.com/thephpleague/factory-muffin): enable the rapid creation of objects (PHP port of factory-girl)
 - [`nelmio/alice`](https://github.com/nelmio/alice): Fixtures/object generator with a yaml DSL that can use Faker as data generator.


### PR DESCRIPTION
Hello!

I recently released https://github.com/JonPurvis/faker-stripe and thought it would be good to include it in the 3rd Party Libraries page in case anyone else needs it.

Thanks!