### PR TITLE
Remove extra character from emoji description

### DIFF
--- a/docs/formatters/miscellaneous.md
+++ b/docs/formatters/miscellaneous.md
@@ -99,7 +99,7 @@ echo $faker->currencyCode();
 ## `emoji`
 
 Generate a random emoji.
-K
+
 ```php
 echo $faker->emoji();
 


### PR DESCRIPTION
Removes a `K` character floating around in the `emoji()` description