### PR TITLE
docs: broken links in the Localization section

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -160,7 +160,7 @@ for ($i = 0; $i < 3; $i++) {
 // Roger Le Voisin
 ```
 
-You can check available Faker locales in the source code, [under the `Provider` directory](https://github.com/FakerPHP/Faker/tree/main/src/Faker/Provider). The localization of Faker is an ongoing process, for which we need your help. Don't hesitate to create localized providers to your own locale and submit a PR!
+You can check available Faker locales in the source code, [under the `Provider` directory](https://github.com/FakerPHP/Faker/tree/2.0/src/Provider). The localization of Faker is an ongoing process, for which we need your help. Don't hesitate to create localized providers to your own locale and submit a PR!
 
 ## Seeding the Generator
 


### PR DESCRIPTION
Hello! 
[Localization](https://fakerphp.github.io/#localization) to the Provider directory in the Localication section is 404, I will send you a PR with the correct link corrected.
