### PR TITLE
Correct status badge url as per needs

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,8 +1,8 @@
 # Faker
 
 [![Packagist Downloads](https://img.shields.io/packagist/dm/FakerPHP/Faker)](https://packagist.org/packages/fakerphp/faker)
-[![GitHub Workflow Status](https://img.shields.io/github/workflow/status/FakerPHP/Faker/Continuous%20Integration/main)](https://github.com/FakerPHP/Faker/actions)
-[![GitHub Workflow Status](https://img.shields.io/github/actions/workflow/status/FakerPHP/Faker/tests.yaml?branch=2.0)
+[![GitHub Workflow Status](https://img.shields.io/github/actions/workflow/status/FakerPHP/Faker/tests.yaml
+)](https://github.com/FakerPHP/Faker/actions)
 
 Faker is a PHP library that generates fake data for you. Whether you need to bootstrap your database, create good-looking XML documents, fill-in your persistence to stress test it, or anonymize data taken from a production service, Faker is for you.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,6 +2,7 @@
 
 [![Packagist Downloads](https://img.shields.io/packagist/dm/FakerPHP/Faker)](https://packagist.org/packages/fakerphp/faker)
 [![GitHub Workflow Status](https://img.shields.io/github/workflow/status/FakerPHP/Faker/Continuous%20Integration/main)](https://github.com/FakerPHP/Faker/actions)
+[![GitHub Workflow Status](https://img.shields.io/github/actions/workflow/status/FakerPHP/Faker/tests.yaml?branch=2.0)
 
 Faker is a PHP library that generates fake data for you. Whether you need to bootstrap your database, create good-looking XML documents, fill-in your persistence to stress test it, or anonymize data taken from a production service, Faker is for you.
 


### PR DESCRIPTION
Currently the badge on https://fakerphp.github.io/ contains an url (not linked, so can't click it.) The url is shows is https://github.com/badges/shields/issues/8671

Where it is explained how to adjust the badge. This PR actually does just that.